### PR TITLE
Fix wavelength axis with Seabreeze for some devices

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,7 @@ Authors
 
 * Sebastien J. Weber
 * Nicolas Tappy
+* Arnaud Meyer
 
 Instruments
 ===========

--- a/src/pymodaq_plugins_oceaninsight/daq_viewer_plugins/plugins_1D/daq_1Dviewer_Seabreeze.py
+++ b/src/pymodaq_plugins_oceaninsight/daq_viewer_plugins/plugins_1D/daq_1Dviewer_Seabreeze.py
@@ -12,14 +12,15 @@ from seabreeze.spectrometers import Spectrometer, list_devices
 
 
 class DAQ_1DViewer_Seabreeze(DAQ_Viewer_base):
-    """
-    """
+    """PyMoDAQ 1DViewer class for devices supported by the Seabreeze library."""
+
     # Upon initialisation
     devices = list_devices()
 
-    #Supports pseudo hardware-averaging
+    # Supports pseudo hardware-averaging
     hardware_averaging = True
 
+    # Adjustable parameters
     params = comon_parameters + [
         {'title': 'Device:', 'name': 'device', 'type': 'list', 'limits': devices},
         {'title': 'Integration (ms):', 'name': 'integration', 'type': 'float', 'value': 1.0},

--- a/src/pymodaq_plugins_oceaninsight/daq_viewer_plugins/plugins_1D/daq_1Dviewer_Seabreeze.py
+++ b/src/pymodaq_plugins_oceaninsight/daq_viewer_plugins/plugins_1D/daq_1Dviewer_Seabreeze.py
@@ -29,7 +29,7 @@ class DAQ_1DViewer_Seabreeze(DAQ_Viewer_base):
             {'title': 'Non Linearity correction:', 'name': 'correct_non_linearity', 'type': 'bool', 'value': False},
             {'title': 'Max Intensity', 'name': 'max_intensity', 'type': "float", 'value': 65535, 'readonly': True},
             {'title': 'Pixels:', 'name': 'pixels', 'type': 'int', 'value': 2048, 'readonly': True},
-            {'title': 'Dark Channels:', 'name': 'dark_channels', 'type': 'int', 'value': 10, 'readonly': True},
+            {'title': 'Dark Channels:', 'name': 'dark_channels', 'type': 'str', 'value': '', 'readonly': True},
             {'title': 'Readout Time (ms)', 'name': 'readout_time', 'type': 'float', 'value': 666, 'readonly': True},
         ]}
     ]
@@ -70,9 +70,9 @@ class DAQ_1DViewer_Seabreeze(DAQ_Viewer_base):
             #####################################
 
         # Oceanoptics spectrometers (at least the ones i Know) have fixed axis
-        # get inactive pixels
+        # get index of inactive pixels
         dark_indices = self.controller.f.spectrometer.get_electric_dark_pixel_indices()
-        #self.settings.child('advanced').child('dark_channels').setValue(dark_indices)
+        self.settings.child('advanced').child('dark_channels').setValue(", ".join([str(x) for x in dark_indices]))
         # get the x_axis
         data_x_axis = self.controller.wavelengths()  # Way to get the x axis
         # keep range without dark pixels

--- a/src/pymodaq_plugins_oceaninsight/daq_viewer_plugins/plugins_1D/daq_1Dviewer_Seabreeze.py
+++ b/src/pymodaq_plugins_oceaninsight/daq_viewer_plugins/plugins_1D/daq_1Dviewer_Seabreeze.py
@@ -71,12 +71,16 @@ class DAQ_1DViewer_Seabreeze(DAQ_Viewer_base):
 
         # Oceanoptics spectrometers (at least the ones i Know) have fixed axis
         # get inactive pixels
-        c0 = self.controller.f.spectrometer.get_electric_dark_pixel_indices()[-1]
-        self.settings.child('advanced').child('dark_channels').setValue(c0)
+        dark_indices = self.controller.f.spectrometer.get_electric_dark_pixel_indices()
+        #self.settings.child('advanced').child('dark_channels').setValue(dark_indices)
         # get the x_axis
         data_x_axis = self.controller.wavelengths()  # Way to get the x axis
-        data_x_axis = data_x_axis[c0:] * 1e9  # Get rid of the dark pixels
-        self.x_axis = Axis(data=data_x_axis, label='wavelength', units='m', index=0)
+        # keep range without dark pixels
+        x_indices = np.arange(data_x_axis.shape[0])
+        self.valid_range = np.setdiff1d(x_indices, dark_indices)
+        data_x_axis = data_x_axis[self.valid_range]
+        # generate PyMoDAQ axis
+        self.x_axis = Axis(data=data_x_axis * 1e-9, label='wavelength', units='m', index=0)
 
         # Get the name
         specname = f"Ocean Insight {self.controller.model}"
@@ -135,16 +139,18 @@ class DAQ_1DViewer_Seabreeze(DAQ_Viewer_base):
         kwargs: (dict) of others optionals arguments
         """
         nlc = self.settings.child('advanced').child('correct_non_linearity').value()
-        c0 = self.settings.child('advanced').child('dark_channels').value()
+        #c0 = self.settings.child('advanced').child('dark_channels').value()
+
         # synchrone version (blocking function)
         # Pseudo-hardware-averaging
         if Naverage > 1:
-            data = [self.controller.intensities(correct_nonlinearity=nlc)[c0:] for i in range(Naverage)]
+            data = [self.controller.intensities(correct_nonlinearity=nlc)[self.valid_range]
+                    for i in range(Naverage)]
             data = np.array(data)
             data = data.mean(0)
         # Otherwise normal single-acquisition
         else:
-            data = self.controller.intensities(correct_nonlinearity=nlc)[c0:]
+            data = self.controller.intensities(correct_nonlinearity=nlc)[self.valid_range]
 
         self.dte_signal.emit(DataToExport('Spectro', data=[
             DataFromPlugins(name='oceanseabreeze', data=[data], dim='Data1D',


### PR DESCRIPTION
Fixes a problem that causes the Seabreeze driver to generate only a single wavelength value (instead of a vector) as the measurement x-axis.

It occurred in my case with an OceanOptics QR65000: measurement is fine using Omnidriver, but only 1 point of the spectrum is retrieved using Seabreeze.

This is caused by the handling of dark pixels: the seabreeze driver returns (via `.get_electric_dark_pixel_indices()`) a list of indices which should be ignored in both x and y axes. In the current version of the plugin, only the last value of this list is considered, and only values _from_ this index are kept:

```
c0 = self.controller.f.spectrometer.get_electric_dark_pixel_indices()[-1]
...
data_x_axis = data_x_axis[c0:] * 1e9  # Get rid of the dark pixels
```

With my QR65000, this last value is 1043, and the number of wavelengths is 1044, so only the last value of the vector is considered.

This PR modifies this behavior by explicitly excluding every single index referenced by `.get_electric_dark_pixel_indices()` from both x-axis and y-axis data, using an internal array `.valid_range` that contains the indices of all "good" pixels.
Also, the read-only parameter `dark_channels` was changed from a single `int` to a comma-separated list of indices.

I also believe that the multiplication factor of `1e9` in the units was the wrong way around (in my case at least, `.wavelengths()` gives values in nm). This is also corrected here.